### PR TITLE
Comment fix; uartNTxSend -> uartNTxAvailable

### DIFF
--- a/libraries/src/uart/core/uart.c
+++ b/libraries/src/uart/core/uart.c
@@ -212,7 +212,7 @@ uint8 uartNTxAvailable(void)
 
 void uartNTxSend(const uint8 XDATA * buffer, uint8 size)
 {
-    // Assumption: uartNTxSend() was recently called and it returned a number at least as big as 'size'.
+    // Assumption: uartNTxAvailable() was recently called and it returned a number at least as big as 'size'.
     // TODO: after DMA memcpy is implemented, use it to make this function faster
 
     while (size)


### PR DESCRIPTION
I'm reasonably sure this is correct based on other spots in the code (and that uartNTxSend() doesn't return anything).  This typo is also present in uart0.c and uart1.c, which I infer I got from the wixel-sdk download at Pololu.com, as they're not under version control.
