### PR TITLE
fixed compile error

### DIFF
--- a/libraries/src/usb/usb.c
+++ b/libraries/src/usb/usb.c
@@ -8,7 +8,7 @@
 
 extern uint8 CODE usbConfigurationDescriptor[];
 
-void usbStandardDeviceRequestHandler();
+static void usbStandardDeviceRequestHandler();
 
 #define CONTROL_TRANSFER_STATE_NONE  0
 #define CONTROL_TRANSFER_STATE_WRITE 1


### PR DESCRIPTION
There was a storage type conflict in the declaration and definition of a function in usb.c
This was an issue in sdcc 3.5.0 in linux. I haven't tried other platforms.

<pre><code>
$ make
Compiling libraries/src/usb/usb.rel
libraries/src/usb/usb.c:298: error 146: two or more storage classes in declaration for 'usbStandardDeviceRequestHandler'
Makefile:172: recipe for target 'libraries/src/usb/usb.rel' failed
make: *** [libraries/src/usb/usb.rel] Error 1
</code></pre>
